### PR TITLE
Add bottom padding fallback to fix mobile post uploads

### DIFF
--- a/app/assets/stylesheets/application/components/modal.scss
+++ b/app/assets/stylesheets/application/components/modal.scss
@@ -72,6 +72,7 @@
     flex: 1;
     overflow: auto;
     scroll-behavior: smooth;
+    padding-bottom: var(--size-navbar); // Fallback; allows post creation on older iPhone Safari
     padding-bottom: calc(var(--size-safe-bottom) + 2rem);
 
     @media (min-width: $tablet) {


### PR DESCRIPTION
Possible solution to close #34 where mobile safari didn't seem to be obeying the 2rem padding in the `calc` the line below.